### PR TITLE
Утили могут принимать заказы

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -12,6 +12,7 @@
   - Salvage
   - Maintenance
   - External
+  - Orders
 
 - type: startingGear
   id: SalvageSpecialistGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
У дельты утилизаторы не считаются отделом снабжения, следовательно не могут принимать запросы в консоли заказов в то время как у оффов - могут
Решает https://discord.com/channels/1087086788092371004/1090548015468642354/threads/1208863088879730768
